### PR TITLE
Fix Invalid URI Errors for content without URLs

### DIFF
--- a/src/Umbraco.Community.FrontDoorCache/ContentSavedNotificationHandler.cs
+++ b/src/Umbraco.Community.FrontDoorCache/ContentSavedNotificationHandler.cs
@@ -146,7 +146,6 @@ namespace Umbraco.Community.FrontDoorCache
 
                     if (!string.IsNullOrEmpty(url))
                     {
-                        _logger.LogTrace($"Found content to purge with URL: {url}");
                         var uri = new UriBuilder(url);
                         contentPaths.Add(uri.Path);
                     }

--- a/src/Umbraco.Community.FrontDoorCache/ContentSavedNotificationHandler.cs
+++ b/src/Umbraco.Community.FrontDoorCache/ContentSavedNotificationHandler.cs
@@ -137,8 +137,12 @@ namespace Umbraco.Community.FrontDoorCache
                 foreach (var culture in content.Cultures)
                 {
                     var url = content.Url(_publishedUrlProvider, CultureOrNull(culture) , UrlMode.Absolute);
-                    var uri = new UriBuilder(url);
-                    contentPaths.Add(uri.Path);
+                    if (!string.IsNullOrEmpty(url))
+                    {
+                        _logger.LogTrace($"Found content to purge with URL: {url}");
+                        var uri = new UriBuilder(url);
+                        contentPaths.Add(uri.Path);
+                    }
                 }
             }
 
@@ -151,7 +155,5 @@ namespace Umbraco.Community.FrontDoorCache
             }
         }
 
-
     }
-
 }

--- a/src/Umbraco.Community.FrontDoorCache/ContentSavedNotificationHandler.cs
+++ b/src/Umbraco.Community.FrontDoorCache/ContentSavedNotificationHandler.cs
@@ -136,7 +136,14 @@ namespace Umbraco.Community.FrontDoorCache
             {
                 foreach (var culture in content.Cultures)
                 {
-                    var url = content.Url(_publishedUrlProvider, CultureOrNull(culture) , UrlMode.Absolute);
+                    var url = content.Url(_publishedUrlProvider, CultureOrNull(culture), UrlMode.Absolute);
+
+                    // content.Url returns '#' for any content without an URL for legacy purposes
+                    if (string.Equals(url, "#"))
+                    {
+                        continue;
+                    }
+
                     if (!string.IsNullOrEmpty(url))
                     {
                         _logger.LogTrace($"Found content to purge with URL: {url}");

--- a/src/Umbraco.Community.FrontDoorCache/ContentSavedNotificationHandler.cs
+++ b/src/Umbraco.Community.FrontDoorCache/ContentSavedNotificationHandler.cs
@@ -136,10 +136,10 @@ namespace Umbraco.Community.FrontDoorCache
             {
                 foreach (var culture in content.Cultures)
                 {
-                    var url = content.Url(_publishedUrlProvider, CultureOrNull(culture), UrlMode.Absolute);
+                    var url = content.Url(_publishedUrlProvider, CultureKeyOrNull(culture), UrlMode.Absolute);
 
                     // content.Url returns '#' for any content without an URL for legacy purposes
-                    if (string.Equals(url, "#"))
+                    if (url.Equals("#"))
                     {
                         continue;
                     }
@@ -155,7 +155,7 @@ namespace Umbraco.Community.FrontDoorCache
             return new FrontDoorPurgeContent(contentPaths);
 
             // If the culture name is empty, null will give us what we want
-            string? CultureOrNull(KeyValuePair<string, PublishedCultureInfo> culture)
+            string? CultureKeyOrNull(KeyValuePair<string, PublishedCultureInfo> culture)
             {
                 return string.IsNullOrEmpty(culture.Key) ? (string?)null : culture.Key;
             }

--- a/src/Umbraco.Community.FrontDoorCache/ContentSavedNotificationHandler.cs
+++ b/src/Umbraco.Community.FrontDoorCache/ContentSavedNotificationHandler.cs
@@ -8,6 +8,7 @@ using Umbraco.Cms.Core.Notifications;
 using Umbraco.Cms.Core.Routing;
 using Umbraco.Cms.Core.Web;
 using Umbraco.Community.FrontDoorCache.Api;
+using Umbraco.Community.FrontDoorCache.Culture;
 using Umbraco.Community.FrontDoorCache.Settings;
 using Umbraco.Extensions;
 
@@ -136,7 +137,8 @@ namespace Umbraco.Community.FrontDoorCache
             {
                 foreach (var culture in content.Cultures)
                 {
-                    var url = content.Url(_publishedUrlProvider, CultureKeyOrNull(culture), UrlMode.Absolute);
+                    // If the culture name is empty, null will give us what we want
+                    var url = content.Url(_publishedUrlProvider, culture.CultureKeyOrNull(), UrlMode.Absolute);
 
                     // content.Url returns '#' for any content without an URL for legacy purposes
                     if (url.Equals("#"))
@@ -153,12 +155,6 @@ namespace Umbraco.Community.FrontDoorCache
             }
 
             return new FrontDoorPurgeContent(contentPaths);
-
-            // If the culture name is empty, null will give us what we want
-            string? CultureKeyOrNull(KeyValuePair<string, PublishedCultureInfo> culture)
-            {
-                return string.IsNullOrEmpty(culture.Key) ? (string?)null : culture.Key;
-            }
         }
 
     }

--- a/src/Umbraco.Community.FrontDoorCache/Culture/CultureExtensions.cs
+++ b/src/Umbraco.Community.FrontDoorCache/Culture/CultureExtensions.cs
@@ -1,0 +1,12 @@
+using Umbraco.Cms.Core.Models.PublishedContent;
+
+namespace Umbraco.Community.FrontDoorCache.Culture
+{
+    public static class CultureExtensions
+    {
+        public static string? CultureKeyOrNull(this KeyValuePair<string, PublishedCultureInfo> culture)
+        {
+            return string.IsNullOrEmpty(culture.Key) ? (string?)null : culture.Key;
+        }
+    }
+}

--- a/src/Umbraco.Community.FrontDoorCache/MediaSavedNotificationHandler.cs
+++ b/src/Umbraco.Community.FrontDoorCache/MediaSavedNotificationHandler.cs
@@ -122,13 +122,19 @@ namespace Umbraco.Community.FrontDoorCache
                     {
                         continue;
                     }
-                    var url = media.MediaUrl(_publishedUrlProvider, mediaCulture.Key, UrlMode.Relative);
+                    var url = media.MediaUrl(_publishedUrlProvider, CultureOrNull(mediaCulture), UrlMode.Absolute);
                     var uri = new UriBuilder(url);
                     uri.Path = string.Join("/", uri.Path.Split("/").SkipLast());
                     contentPaths.Add(uri.Path + "/*");
                 }
             }
             return new FrontDoorPurgeContent(contentPaths);
+
+            // If the culture name is empty, null will give us what we want
+            string? CultureOrNull(KeyValuePair<string, PublishedCultureInfo> culture)
+            {
+                return string.IsNullOrEmpty(culture.Key) ? (string?)null : culture.Key;
+            }
         }
     }
 }

--- a/src/Umbraco.Community.FrontDoorCache/MediaSavedNotificationHandler.cs
+++ b/src/Umbraco.Community.FrontDoorCache/MediaSavedNotificationHandler.cs
@@ -8,6 +8,7 @@ using Umbraco.Cms.Core.Notifications;
 using Umbraco.Cms.Core.Routing;
 using Umbraco.Cms.Core.Web;
 using Umbraco.Community.FrontDoorCache.Api;
+using Umbraco.Community.FrontDoorCache.Culture;
 using Umbraco.Community.FrontDoorCache.Settings;
 using Umbraco.Extensions;
 
@@ -122,19 +123,13 @@ namespace Umbraco.Community.FrontDoorCache
                     {
                         continue;
                     }
-                    var url = media.MediaUrl(_publishedUrlProvider, CultureKeyOrNull(mediaCulture), UrlMode.Absolute);
+                    var url = media.MediaUrl(_publishedUrlProvider, mediaCulture.CultureKeyOrNull(), UrlMode.Absolute);
                     var uri = new UriBuilder(url);
                     uri.Path = string.Join("/", uri.Path.Split("/").SkipLast());
                     contentPaths.Add(uri.Path + "/*");
                 }
             }
             return new FrontDoorPurgeContent(contentPaths);
-
-            // If the culture name is empty, null will give us what we want
-            string? CultureKeyOrNull(KeyValuePair<string, PublishedCultureInfo> culture)
-            {
-                return string.IsNullOrEmpty(culture.Key) ? (string?)null : culture.Key;
-            }
         }
     }
 }

--- a/src/Umbraco.Community.FrontDoorCache/MediaSavedNotificationHandler.cs
+++ b/src/Umbraco.Community.FrontDoorCache/MediaSavedNotificationHandler.cs
@@ -124,9 +124,14 @@ namespace Umbraco.Community.FrontDoorCache
                         continue;
                     }
                     var url = media.MediaUrl(_publishedUrlProvider, mediaCulture.CultureKeyOrNull(), UrlMode.Absolute);
-                    var uri = new UriBuilder(url);
-                    uri.Path = string.Join("/", uri.Path.Split("/").SkipLast());
-                    contentPaths.Add(uri.Path + "/*");
+
+                    // .MediaUrl returns string.Empty if it cannot be retrieved by provider
+                    if (!string.IsNullOrEmpty(url))
+                    {
+                        var uri = new UriBuilder(url);
+                        uri.Path = string.Join("/", uri.Path.Split("/").SkipLast());
+                        contentPaths.Add(uri.Path + "/*");
+                    }
                 }
             }
             return new FrontDoorPurgeContent(contentPaths);

--- a/src/Umbraco.Community.FrontDoorCache/MediaSavedNotificationHandler.cs
+++ b/src/Umbraco.Community.FrontDoorCache/MediaSavedNotificationHandler.cs
@@ -122,7 +122,7 @@ namespace Umbraco.Community.FrontDoorCache
                     {
                         continue;
                     }
-                    var url = media.MediaUrl(_publishedUrlProvider, CultureOrNull(mediaCulture), UrlMode.Absolute);
+                    var url = media.MediaUrl(_publishedUrlProvider, CultureKeyOrNull(mediaCulture), UrlMode.Absolute);
                     var uri = new UriBuilder(url);
                     uri.Path = string.Join("/", uri.Path.Split("/").SkipLast());
                     contentPaths.Add(uri.Path + "/*");
@@ -131,7 +131,7 @@ namespace Umbraco.Community.FrontDoorCache
             return new FrontDoorPurgeContent(contentPaths);
 
             // If the culture name is empty, null will give us what we want
-            string? CultureOrNull(KeyValuePair<string, PublishedCultureInfo> culture)
+            string? CultureKeyOrNull(KeyValuePair<string, PublishedCultureInfo> culture)
             {
                 return string.IsNullOrEmpty(culture.Key) ? (string?)null : culture.Key;
             }

--- a/src/Umbraco.Community.FrontDoorCache/Umbraco.Community.FrontDoorCache.csproj
+++ b/src/Umbraco.Community.FrontDoorCache/Umbraco.Community.FrontDoorCache.csproj
@@ -22,7 +22,6 @@
 		<SymbolPackageFormat>snupkg</SymbolPackageFormat>
 		<RepositoryUrl>https://github.com/Gibe/Umbraco.Community.FrontDoorCache</RepositoryUrl>
 		<RepositoryType>git</RepositoryType>
-        <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
 	</PropertyGroup>
 
     <ItemGroup>

--- a/src/Umbraco.Community.FrontDoorCache/Umbraco.Community.FrontDoorCache.csproj
+++ b/src/Umbraco.Community.FrontDoorCache/Umbraco.Community.FrontDoorCache.csproj
@@ -5,14 +5,14 @@
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
 		<PackageId>Umbraco.Community.FrontDoorCache</PackageId>
-		<Version>1.0.0</Version>
+		<Version>1.0.3</Version>
 		<Authors>Steve Temple</Authors>
 		<Company>Gibe Digital</Company>
 		<Product>Azure Front Door Cache purging for Umbraco</Product>
 		<ProjectUrl>https://github.com/Gibe/Umbraco.Community.FrontDoorCache</ProjectUrl>
 		<PackageTags>umbraco-marketplace;front-door;azure;cdn</PackageTags>
 		<Copyright>Copyright (c) 2024 Gibe Digital Ltd</Copyright>
-		<Description>Umbraco module to purge items from Azure Front Door Cache when content is publishead</Description>
+		<Description>Umbraco module to purge items from Azure Front Door Cache when content is published</Description>
 		<Title>Umbraco Front Door Cache</Title>
 		<PackageProjectUrl>https://github.com/Gibe/Umbraco.Community.FrontDoorCache</PackageProjectUrl>
 		<PackageIcon>FrontDoorCache.png</PackageIcon>
@@ -22,6 +22,7 @@
 		<SymbolPackageFormat>snupkg</SymbolPackageFormat>
 		<RepositoryUrl>https://github.com/Gibe/Umbraco.Community.FrontDoorCache</RepositoryUrl>
 		<RepositoryType>git</RepositoryType>
+        <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
 	</PropertyGroup>
 
     <ItemGroup>


### PR DESCRIPTION
Fixes an issue where `One or more errors occurred. (One or more errors occurred. (Invalid URI: The hostname could not be parsed.))` is thrown when attempting to clear cache for content items without a URL - this occurs because PublishedContent.Url() returns # for any content without a URL for legacy purposes, which then fails to build a valid URI:

![image](https://github.com/user-attachments/assets/ad7dfae9-17d0-4af4-95f0-a78d40d1d2ee)

![image](https://github.com/user-attachments/assets/c355e69b-0841-4115-b997-b4130af8f18b)

Also fixes media file URL paths being set to relative, which doesn't parse as a valid URI

Tested via local nuget feed. 